### PR TITLE
Add sorting order on root page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,4 +6,14 @@ module ApplicationHelper
     gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: "gravatar img-rounded")
   end
+
+  def sortable_link_to(direction, url_options = {}, title_options = {})
+    css_class = direction == :desc ? 'glyphicon-sort-by-attributes-alt' : 'glyphicon-sort-by-attributes'
+    title = title_options.fetch(direction, direction == :desc ? 'От новых к старым' : 'От старых к новым')
+    direction = direction == :desc ? :asc : :desc
+
+    link_to url_options.merge(direction: direction) do
+      content_tag(:span, title) + content_tag(:span, nil, class: ['glyphicon', css_class])
+    end
+  end
 end

--- a/app/views/welcome/_feed.html.erb
+++ b/app/views/welcome/_feed.html.erb
@@ -48,6 +48,11 @@
     <% end %>
     <% if @section != 'important' %>
       <div id = "notifications" class="notifications">
+        <% if @notifications.many? %>
+          <div class="text-center">
+            <%= sortable_link_to(sort_order, section: @section) %>
+          </div>
+        <% end %>
         <% if (@section == 'unread' && current_user.has_unread_notifications) || (@section == 'show_all' && @notifications.any?) %>
           <%= render @notifications %>
         <% else %>


### PR DESCRIPTION
For #66.

I don't really see any significant improvement from AJAX-request on sort order change. I'll add this functionality if there is such a need.

Preview:
<img width="567" alt="2017-10-24 01 38 47" src="https://user-images.githubusercontent.com/8161569/31916611-3507c618-b85c-11e7-8d2f-8fb1266e4d05.png">