### PR TITLE
Preserve new lines in chat comments

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -140,3 +140,7 @@ h3 {
   border-spacing: 8px;
   border-collapse: separate;
 }
+
+#chat-table p {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Not preserving:
<img src="https://user-images.githubusercontent.com/4586392/39841715-684cf508-53ec-11e8-9b1f-9ceffb81a944.png" width="350">

Preserving:
<img src="https://user-images.githubusercontent.com/4586392/39841705-5bea6160-53ec-11e8-96dd-c7a7e2b8dfb4.png" width="350">

The last one is the best I suppose.